### PR TITLE
track our own IMS repo

### DIFF
--- a/cosmic-os.xml
+++ b/cosmic-os.xml
@@ -120,5 +120,6 @@
   <copyfile dest="build-cos.sh" src="build-cos.sh"/>
   </project>
   <project path="vendor/qcom/binaries" name="platform_vendor_qcom_binaries" remote="cosmic-os" />
+  <project path="frameworks/opt/net/ims" name="platform_frameworks_opt_net_ims" groups="frameworks_ims,pdk-cw-fs,pdk-fs" remote="github" revision="n7.1" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -371,7 +371,6 @@
   <!-- LineageOS -->
   <project path="external/libnfc-nci" name="LineageOS/android_external_libnfc-nci" groups="pdk" remote="github" revision="cm-14.1" />
   <project path="external/libnfc-nxp" name="LineageOS/android_external_libnfc-nxp" groups="pdk" remote="github" revision="cm-14.1" />
-  <project path="frameworks/opt/net/ims" name="LineageOS/android_frameworks_opt_net_ims" groups="frameworks_ims,pdk-cw-fs,pdk-fs" remote="github" revision="cm-14.1" />
   <project path="packages/apps/Nfc" name="LineageOS/android_packages_apps_Nfc" remote="github" revision="cm-14.1" />
   <project path="packages/apps/Snap" name="LineageOS/android_packages_apps_Snap" remote="github" revision="cm-14.1" />
   <project path="packages/apps/WallpaperPicker" name="LineageOS/android_packages_apps_WallpaperPicker" remote="github" revision="cm-14.1" />


### PR DESCRIPTION
cm-14.1 IMS repo is no longer maintained and derprecated, it throws out this error during build. Instead track our own local IMS repo.

`frameworks/opt/net/ims/src/java/com/android/ims/ImsManager.java:839: error: cannot find symbol
                CarrierConfigManager.KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS);
                                    ^
  symbol:   variable KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS
  location: class CarrierConfigManager
frameworks/opt/net/ims/src/java/com/android/ims/ImsManager.java:1459: error: cannot find symbol
                            CarrierConfigManager.KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS);
                                                ^
  symbol:   variable KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS
  location: class CarrierConfigManager
frameworks/opt/net/ims/src/java/com/android/ims/ImsManager.java:1664: error: method does not override or implement a method from a supertype
        @Override
        ^
frameworks/opt/net/ims/src/java/com/android/ims/ImsManager.java:1815: error: cannot find symbol
                CarrierConfigManager.KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS));
                                    ^
  symbol:   variable KEY_IGNORE_DATA_ENABLED_CHANGED_FOR_VIDEO_CALLS
  location: class CarrierConfigManager
Note: frameworks/opt/net/ims/src/java/com/android/ims/ImsUt.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
4 errors`